### PR TITLE
Typescript version error

### DIFF
--- a/src/AspNetCoreSpa.Web/ClientApp/package.json
+++ b/src/AspNetCoreSpa.Web/ClientApp/package.json
@@ -73,7 +73,7 @@
     "protractor": "5.4.2",
     "ts-node": "8.0.2",
     "tslint": "5.13.0",
-    "typescript": "^3.2.4",
+    "typescript": "3.2.4",
     "webpack-bundle-analyzer": "3.0.4"
   },
   "jest": {


### PR DESCRIPTION
1. Clone the repo:
    git clone https://github.com/asadsahi/AspNetCoreSpa
2. Change directory:
    cd AspNetCoreSpa
3. Restore packages:
    dotnet restore AspNetCoreSpa.sln
4. Run client project
    cd src/AspNetCoreSpa.Web/ClientApp:
    4.1. npm install
    4.2. npm start

npm start, gives this error
ERROR in The Angular Compiler requires TypeScript >=3.1.1 and <3.3.0 but 3.3.3333 was found instead.
